### PR TITLE
在庫登録機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,4 +1,22 @@
 class ProductsController < ApplicationController
   def index
   end
+
+  def new
+    @product = Product.new
+  end
+
+  def create
+    @product = Product.new(product_params)
+    if @product.save
+      redirect_to new_product_path
+    else
+      render :new
+    end
+  end
+
+private
+  def product_params
+    params.require(:product).permit(:name, :quantity, :low_quantity)
+  end
 end

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -1,1 +1,1 @@
-View
+= link_to '在庫登録', new_product_path

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -1,0 +1,12 @@
+%h1 在庫登録
+
+-# = form_with(model: @product, url: products_path) do
+= form_for @product, url: {action: 'create'} do |f|
+  %div
+    = f.text_field :name
+  %div
+    = f.number_field :quantity, type: "number", min: "1", max: "9999999", required: true
+  %div
+    = f.number_field :low_quantity, type: "number", min: "1", max: "9999999", required: true
+  %div
+    = f.submit '登録する'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'products#index'
+  resources :products, only:[:new, :create]
 end


### PR DESCRIPTION
# What
在庫登録機能実装

※railsのバージョンが5.0.7.2でform_withが使えなかった為、
form_forで代用。機能の動きは確認できたので、次のブランチでバージョンアップした後に、form_withに変更

# Why
製品名・個数・在庫切れ通知個数をDBに登録できる